### PR TITLE
Add feature to showcase the getting of port settings

### DIFF
--- a/Cisco.py
+++ b/Cisco.py
@@ -74,7 +74,7 @@ class CiscoTelnetSession(object):
 		self.password = ""
 		self.session = 0
 		self.prompt = "#"
-		self.response_timeout = 10
+		self.response_timeout = 15
 
 	def __del__(self):
 		#self.session.write("exit\n")

--- a/Cisco.py
+++ b/Cisco.py
@@ -33,7 +33,7 @@ class CiscoTelnetSession(object):
 	regex_ip = '(?P<ip>[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})'
 	regex_age = '(?P<age>[0-9\-]+)'
 	regex_arptype = '(?P<arptype>ARPA)'
-	regex_vlanid = '(?P<vlanid>([0-9]+|unassigned|trunk))'
+	regex_vlanid = '(?P<vlanid>([0-9]+|unassigned|trunk|dynamic))'
 	regex_vlanname = '(?P<vlanname>[a-zA-Z][0-9a-zA-Z-_]*)'
 	regex_vlanstatus = '(?P<vlanstatus>[a-z/]+)'
 	regex_ports = '(?P<ports>[a-zA-Z0-9, /]*)'
@@ -51,6 +51,8 @@ class CiscoTelnetSession(object):
 	regex_platform = '(?P<platform>[0-9a-zA-Z-]+)'
 	regex_string = "[0-9a-zA-Z]+"
 	regex_patchid = '(?P<patchid>[a-z0-9_]+(\-|\.)[a-z0-9]+(\-|\.)[0-9]+[a-z]?)'
+	regex_vlanconfig = 'switchport access vlan ' + regex_vlanid.replace("vlanid", "vlanconfig")
+
 
 	newline = "\n"
 	character_time_spacing_seconds = 0.1
@@ -83,7 +85,7 @@ class CiscoTelnetSession(object):
 	def execute_command_lowlevel(self, command, timeout = None):
 		"""Execute a command and return the result"""
 		#print self.host + ".execute_command: " + command
-		if timeout is None:
+		if timeout == None:
 			timeout = self.response_timeout
 		commandstr = command + self.newline #.strip() + self.newline
 
@@ -372,6 +374,14 @@ class CiscoTelnetSession(object):
 		command += self.set_single_interface_trunk(interface)
 		command += "end" + self.newline
 		output = self.execute_command(command)
+		return output
+
+	def get_interface_vlan_setting(self):
+		"""Get the vlan settings for all interfaces"""
+		regex = "interface " + CiscoTelnetSession.regex_interface
+		regex += CiscoTelnetSession.regex_whitespace + CiscoTelnetSession.regex_vlanconfig
+		command = "show run | inc (interface)|switchport access vlan" #inc can handle regex!
+		output = self.command_filter(command, regex)
 		return output
 
 class CiscoSet(object):

--- a/Cisco.py
+++ b/Cisco.py
@@ -402,7 +402,7 @@ class CiscoTelnetSession(object):
 			vlansetting = [ x["vlanconfig"] for x in port_setting if x["hostname"] == hostname and CiscoTelnetSession.fix_interfacename(x["interface"]) == interface ]
 			try:
 				port["vlanconfig"] = vlansetting[0]
-			except:
+			except IndexError:
 				pass
 		return port_status
 

--- a/network_overview.py
+++ b/network_overview.py
@@ -3,7 +3,6 @@
 import sys
 import json
 
-from portconfig import fix_interfacename
 from Cisco import CiscoTelnetSession, CiscoSet
 
 telnet_port = 23
@@ -55,11 +54,11 @@ if __name__ == '__main__':
 	vlans = vlan_switch.show_vlan()
 
 	mac = switchset.execute_on_all(CiscoTelnetSession.show_mac_address_table)
-	all_ports = switchset.execute_on_all(CiscoTelnetSession.show_interface_vlan)
+	all_ports = switchset.execute_on_all(CiscoTelnetSession.get_interface_status_and_setting)
 
 	port_settings = switchset.execute_on_all(CiscoTelnetSession.get_interface_vlan_setting)
 	for port_setting in port_settings:
-		port_setting["interface"] = fix_interfacename(port_setting["interface"])
+		port_setting["interface"] = CiscoTelnetSession.fix_interfacename(port_setting["interface"])
 
 	for mac_entry in mac:
 		mac_entry.pop("macaddress_type") #Remove uninteresting info before printing
@@ -67,5 +66,5 @@ if __name__ == '__main__':
 		mac_entry["vlanname"] = get_vlan_name(vlans, mac_entry["vlanid"])
 		mac_entry["patchid"] = get_port_patchid(all_ports, mac_entry["hostname"], mac_entry["port"])
 
-	json_list = { "arp" : arp, "mac" : mac, "ports" : all_ports, "portsettings" : port_settings }
+	json_list = { "arp" : arp, "mac" : mac, "ports" : all_ports }
 	print json.dumps(json_list)

--- a/network_overview.py
+++ b/network_overview.py
@@ -3,7 +3,7 @@
 import sys
 import json
 
-
+from portconfig import fix_interfacename
 from Cisco import CiscoTelnetSession, CiscoSet
 
 telnet_port = 23
@@ -57,11 +57,15 @@ if __name__ == '__main__':
 	mac = switchset.execute_on_all(CiscoTelnetSession.show_mac_address_table)
 	all_ports = switchset.execute_on_all(CiscoTelnetSession.show_interface_vlan)
 
+	port_settings = switchset.execute_on_all(CiscoTelnetSession.get_interface_vlan_setting)
+	for port_setting in port_settings:
+		port_setting["interface"] = fix_interfacename(port_setting["interface"])
+
 	for mac_entry in mac:
 		mac_entry.pop("macaddress_type") #Remove uninteresting info before printing
 		mac_entry["uncertainty"] = count_mac_addresses(mac, mac_entry["hostname"], mac_entry["port"])
 		mac_entry["vlanname"] = get_vlan_name(vlans, mac_entry["vlanid"])
 		mac_entry["patchid"] = get_port_patchid(all_ports, mac_entry["hostname"], mac_entry["port"])
 
-	json_list = { "arp" : arp, "mac" : mac, "ports" : all_ports }
+	json_list = { "arp" : arp, "mac" : mac, "ports" : all_ports, "portsettings" : port_settings }
 	print json.dumps(json_list)

--- a/network_overview.py
+++ b/network_overview.py
@@ -55,6 +55,13 @@ if __name__ == '__main__':
 
 	mac = switchset.execute_on_all(CiscoTelnetSession.show_mac_address_table)
 	all_ports = switchset.execute_on_all(CiscoTelnetSession.get_interface_status_and_setting)
+	for port in all_ports:
+		try:
+			port["vlanname"] = get_vlan_name(vlans, port["vlanid"])
+			port["vlanconfigname"] = get_vlan_name(vlans, port["vlanconfig"])
+		except KeyError:
+			pass
+		
 
 	port_settings = switchset.execute_on_all(CiscoTelnetSession.get_interface_vlan_setting)
 	for port_setting in port_settings:

--- a/network_overview.py
+++ b/network_overview.py
@@ -61,7 +61,6 @@ if __name__ == '__main__':
 			port["vlanconfigname"] = get_vlan_name(vlans, port["vlanconfig"])
 		except KeyError:
 			pass
-		
 
 	port_settings = switchset.execute_on_all(CiscoTelnetSession.get_interface_vlan_setting)
 	for port_setting in port_settings:

--- a/portconfig.py
+++ b/portconfig.py
@@ -66,24 +66,11 @@ def fix_patchid(patchid):
 	patchid_corrected = '-'.join(new_elements)
 	return patchid_corrected
 
-def fix_interfacename(interface_name):
-	"""Fix common changes in interface naming. GigabitEthernet vs Gi"""
-	ret = interface_name.replace("GigabitEthernet", "Gi")
-	ret = ret.replace("FastEthernet", "Fa")
-	ret = ret.replace("TenGigabitEthernet", "Te")
-	return ret
-
 def get_available_patchports(hostname, port, username, password):
 	"""Get all available patchports"""
 	switches = CiscoSet(username, password, hostname, port)
 	switches.discover_devices()
-	all_ports = switches.execute_on_all(CiscoTelnetSession.show_interface_vlan)
-	all_port_settings = switches.execute_on_all(CiscoTelnetSession.get_interface_vlan_setting)
-	for port in all_ports: #Insert VLAN settings from that request
-		hostname = port["hostname"]
-		interface = port["interface"]
-		vlansetting = [ x["vlanconfig"] for x in all_port_settings if x["hostname"] == hostname and fix_interfacename(x["interface"]) == interface ]
-		port["vlanconfig"] = vlansetting
+	all_ports = switches.execute_on_all(CiscoTelnetSession.get_interface_status_and_setting)
 	all_ports_sorted = sorted(all_ports, key=lambda k : fix_patchid(k['patchid']))
 	return all_ports_sorted
 

--- a/portconfig.py
+++ b/portconfig.py
@@ -66,11 +66,24 @@ def fix_patchid(patchid):
 	patchid_corrected = '-'.join(new_elements)
 	return patchid_corrected
 
+def fix_interfacename(interface_name):
+	"""Fix common changes in interface naming. GigabitEthernet vs Gi"""
+	ret = interface_name.replace("GigabitEthernet", "Gi")
+	ret = ret.replace("FastEthernet", "Fa")
+	ret = ret.replace("TenGigabitEthernet", "Te")
+	return ret
+
 def get_available_patchports(hostname, port, username, password):
 	"""Get all available patchports"""
 	switches = CiscoSet(username, password, hostname, port)
 	switches.discover_devices()
 	all_ports = switches.execute_on_all(CiscoTelnetSession.show_interface_vlan)
+	all_port_settings = switches.execute_on_all(CiscoTelnetSession.get_interface_vlan_setting)
+	for port in all_ports: #Insert VLAN settings from that request
+		hostname = port["hostname"]
+		interface = port["interface"]
+		vlansetting = [ x["vlanconfig"] for x in all_port_settings if x["hostname"] == hostname and fix_interfacename(x["interface"]) == interface ]
+		port["vlanconfig"] = vlansetting
 	all_ports_sorted = sorted(all_ports, key=lambda k : fix_patchid(k['patchid']))
 	return all_ports_sorted
 


### PR DESCRIPTION
This showcases the feature to get the vlan config of all ports, in contrast with the actual vlan setting which the software previously returned.
There is only a difference when `dynamic` ports are in use.

The portconfig.py script shows how to use the new command and merge the answer.
Since the `show run` command is rather heavy to run on large stacks, I've chosen not to do this by default. Care should be taken with the new request.